### PR TITLE
change go version of travis env to 1.18.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ service:
   - docker
 
 go:
-   - "1.17.x"
+   - "1.18.x"
 
 os:
   - linux


### PR DESCRIPTION
Signed-off-by: Riko Kudo <rurikudo@ibm.com>